### PR TITLE
Pdnd "save-dataset" snippet patch

### DIFF
--- a/packages/pdnd-nteract-packages/save-dataset/SaveDatasetForm.tsx
+++ b/packages/pdnd-nteract-packages/save-dataset/SaveDatasetForm.tsx
@@ -35,7 +35,7 @@ const SaveDatasetForm: FunctionComponent<
     ].reduce(
       (accumulator, [key, value]) => ({
         ...accumulator,
-        [key.replace(idPrefix, "")]: value
+        [key.replace(idPrefix, "")]: value.replace(/ /gi, '_')
       }),
       {}
     );


### PR DESCRIPTION
Since inputs provided by "SaveDatasetForm" can
contains space characters and we are using these
values also for writing temporary dataset on
filesystem, this commit will patch all values
provided on form submit replacing all " " characters
with "_"

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [ ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
